### PR TITLE
Support shorthand CSS, closes #2

### DIFF
--- a/lib/flutter_color_plugin.dart
+++ b/lib/flutter_color_plugin.dart
@@ -27,6 +27,13 @@ class ColorUtil {
       if (colorString.length == 7) {
         // Set the alpha value
         color |= 0x00000000ff000000;
+      } else if (colorString.length == 4) {
+        String convertedToHex = colorString
+          .substring(1)
+          .split('')
+          .map((String char) => char + char)
+          .join('');
+        return intColor('#$convertedToHex');
       } else if (colorString.length != 9) {
         throw ArgumentError('Unknown color');
       }


### PR DESCRIPTION
Small update to add support for shorthand CSS like `#ccc`, `#000`, etc.
For example `#0f0` (R: 0, G: 255, B: 0) will internally be converted to `#00ff00` first and then parsed to green.
Code example:
```
ColorUtil.color("#0f0")
```